### PR TITLE
Inital draft for subscription groups: Create, change and delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 node_modules
+.idea

--- a/services/discord-autocompletes/subgroup/add.js
+++ b/services/discord-autocompletes/subgroup/add.js
@@ -1,0 +1,63 @@
+import { ISK_PREFIX, LABEL_PREFIX, SUGGESTION_LABEL_FILTERS, LABEL_FILTERS } from "../../../util/constants.js";
+import {handleGroupName} from "../../../util/subgroup.js";
+
+export async function autocomplete(db, interaction) {
+    const { guildId, channelId } = interaction;
+
+    const focused = interaction.options.getFocused(true);
+    if (focused.name === "group_name") {
+        return handleGroupName(db, interaction);
+    }
+    // TODO: Rewrite using focused option above
+    const valueRaw = interaction.options.getString("filter");
+
+    if (valueRaw === '') {
+        return interaction.respond([
+            { name: 'C C P Alliance (alliance)', value: `434243723` },
+            { name: 'Eve University', value: `917701062` },
+            { name: `El'Miner (character)`, value: `277137239` },
+            { name: 'Jita (system)', value: `30000142` },
+            { name: 'Sabre (ship)', value: `22456` },
+            { name: 'ISK (currency)', value: 'isk:1000000000' },
+            { name: 'Highsec', value: 'label:loc:highsec' },
+            { name: 'Big ISK - Killmails valued over 10b ISK', value: 'label:bigisk' },
+        ]);
+    }
+
+    if (valueRaw.startsWith(ISK_PREFIX)) {
+        return interaction.respond([
+            { name: '100 million ISK', value: `isk:100000000` },
+            { name: '1 billion ISK', value: `isk:1000000000` },
+            { name: '10 billion ISK', value: `isk:10000000000` },
+            { name: '25 billion ISK', value: `isk:25000000000` },
+            { name: '50 billion ISK', value: `isk:50000000000` },
+            { name: '100 billion ISK', value: `isk:100000000000` },
+            { name: '1 trillion ISK', value: `isk:1000000000000` },
+        ]);
+    }
+
+    if (valueRaw.startsWith(LABEL_PREFIX)) {
+        // get the prefix they're using, if any
+        const label_filter = valueRaw.slice(LABEL_PREFIX.length).trim().toLowerCase();
+        const filtered = label_filter.trim().length == 0 ? SUGGESTION_LABEL_FILTERS : LABEL_FILTERS.filter(l => l.startsWith(label_filter));
+        const choices = filtered.map(l => ({
+            name: l,
+            value: `label:${l}`
+        }));
+        return interaction.respond(choices.slice(0, 25));
+    }
+
+    const res = await fetch(`https://zkillboard.com/cache/1hour/autocomplete/?query=${valueRaw}`);
+    let suggestions = (await res.json()).suggestions;
+
+    // we will add groups, but omitting for now
+    suggestions = suggestions.filter(
+        s => !s.value.includes("(Closed)") && s.data.type != "group" && !s.value.includes("(recycled)")
+    );
+
+    const choices = suggestions.map(s => ({
+        name: `${s.value} (${s.data.type})`, // what shows in the dropdown
+        value: `${s.data.id}`               // what gets sent back if selected
+    }));
+    await interaction.respond(choices.slice(0, 25));
+}

--- a/services/discord-autocompletes/subgroup/delete.js
+++ b/services/discord-autocompletes/subgroup/delete.js
@@ -1,0 +1,10 @@
+import {handleGroupName} from "../../../util/subgroup.js";
+
+export async function autocomplete(db, interaction) {
+    const { guildId, channelId } = interaction;
+
+    const focused = interaction.options.getFocused(true);
+    if (focused.name === "group_name") {
+        return handleGroupName(db, interaction);
+    }
+}

--- a/services/discord-autocompletes/subgroup/remove.js
+++ b/services/discord-autocompletes/subgroup/remove.js
@@ -1,0 +1,45 @@
+import { getNames } from "../../information.js";
+import {handleGroupName} from "../../../util/subgroup.js";
+
+export async function autocomplete(db, interaction) {
+	const { guildId, channelId } = interaction;
+
+    const focused = interaction.options.getFocused(true);
+    if (focused.name === "group_name") {
+        return handleGroupName(db, interaction);
+    }
+    // TODO: Rewrite using focused option above
+	try {
+		const value = interaction.options.getString("filter");
+
+		const doc = (await db.subsCollection.findOne({ guildId, channelId })).subgroups[interaction.options.getString("group_name")];
+		let entityIds = doc?.entityIds || [];
+
+		const names = await getNames(db, entityIds);
+		const options = [];
+
+		for (const id in names) {
+			options.push({ name: `${id}:${names[id]}`, value: `${id}` });
+		}
+
+		const labels = doc?.labels || [];
+		for (let label of labels) {
+			options.push({ name: `label:${label}`, value: `label:${label}` });
+		}
+
+		if (doc?.iskValue) {
+			options.push({ name: `isk:${doc.iskValue}`, value: `isk:${doc.iskValue}` });
+		}
+
+		if (value) {
+			await interaction.respond(
+				options.filter(opt => opt.name.toLowerCase().includes(value.toLowerCase())).slice(0, 25)
+			);
+		} else {
+			await interaction.respond(options.slice(0, 25));
+		}
+	} catch (err) {
+		console.error("AutoComplete error:", err);
+	}
+
+}

--- a/services/discord-commands.js
+++ b/services/discord-commands.js
@@ -49,5 +49,71 @@ export const SLASH_COMMANDS = [
 				.setName("remove_all_subs")
 				.setDescription("Clears all subscriptions in this channel")
 		)
+        .addSubcommandGroup(sub =>
+            sub
+                .setName("subgroup")
+                .setDescription('Manage subscription groups')
+                .addSubcommand(sub =>
+                    sub
+                        .setName('create')
+                        .setDescription('Create a new subscription group')
+                        .addStringOption(opt =>
+                        opt
+                            .setName("group_name")
+                            .setDescription("Name of the subscription group")
+                            .setRequired(true)
+                        )
+                )
+                .addSubcommand(sub =>
+                    sub
+                        .setName('delete')
+                        .setDescription('Delete a subscription group')
+                        .addStringOption(opt =>
+                            opt
+                                .setName("group_name")
+                                .setDescription("Name of the subscription group")
+                                .setAutocomplete(true)
+                                .setRequired(true)
+                        )
+                )
+                .addSubcommand(sub =>
+                    sub
+                        .setName('add')
+                        .setDescription('Add by name, ID, or prefixed with isk: or label: to a group')
+                        .addStringOption(opt =>
+                            opt
+                                .setName("group_name")
+                                .setDescription("Name of the subscription group")
+                                .setAutocomplete(true)
+                                .setRequired(true)
+                        )
+                        .addStringOption(opt =>
+                            opt
+                                .setName("filter")
+                                .setDescription("Subscribe by name, ID, or prefixed with isk: or label:")
+                                .setRequired(true)
+                                .setAutocomplete(true)
+                        )
+                )
+                .addSubcommand(sub =>
+                    sub
+                        .setName('remove')
+                        .setDescription('remove by name, ID, or prefixed with isk: or label: to a group')
+                        .addStringOption(opt =>
+                            opt
+                                .setName("group_name")
+                                .setDescription("Name of the subscription group")
+                                .setAutocomplete(true)
+                                .setRequired(true)
+                        )
+                        .addStringOption(opt =>
+                            opt
+                                .setName("filter")
+                                .setDescription("Unsubscribe by name, ID, or prefixed with isk: or label:")
+                                .setRequired(true)
+                                .setAutocomplete(true)
+                        )
+                )
+        )
 		.toJSON()
 ];

--- a/services/discord-interactions.js
+++ b/services/discord-interactions.js
@@ -1,15 +1,21 @@
 import { readdirSync } from "fs";
 import path from "path";
+import {lstatSync} from "fs";
 
-async function handleImports(directory) {
-	const object = {};
+async function handleImports(directory, prefix = "") {
+	let object = {};
 	const dir = new URL(directory, import.meta.url).pathname;
 
 	for (const file of readdirSync(dir)) {
 		if (file.endsWith(".js")) {
 			const name = path.basename(file, ".js");
-			object[name] = await import(`${dir}/${file}`);
+			object[prefix+name] = await import(`${dir}/${file}`);
+            continue;
 		}
+        const subdir = path.join(dir, file)
+        if (lstatSync(subdir).isDirectory()) {
+            object = Object.assign(object, await handleImports(subdir, file+"_"));
+        }
 	}
 	return object;
 }
@@ -21,7 +27,13 @@ export async function handleInteractions(client) {
 	// --- interaction handling ---
 	client.on("interactionCreate", async (interaction) => {
 		const db = interaction.client.db;
-		const sub = interaction.options.getSubcommand();
+        const subGroup = interaction.options.getSubcommandGroup();
+        let sub = null;
+        if (subGroup) {
+            sub = subGroup + '_' + interaction.options.getSubcommand();
+        } else {
+            sub = interaction.options.getSubcommand();
+        }
 
 		try {
 			if (interaction.isAutocomplete()) {

--- a/services/discord-interactions/subgroup/add.js
+++ b/services/discord-interactions/subgroup/add.js
@@ -1,0 +1,93 @@
+import { ISK_PREFIX, LABEL_PREFIX, LABEL_FILTERS } from "../../../util/constants.js";
+import { getNames } from "../../information.js";
+import { getFirstString, unixtime } from "../../../util/helpers.js";
+
+export async function interaction(db, interaction) {
+    const { guildId, channelId } = interaction;
+
+    let doc = await db.subsCollection.findOne({ channelId: channelId });
+    if (!doc || doc.checked != true) {
+        return ' 🛑 Before you subscribe, please run `/zkillbot check`` to ensure all permissions are set properly for this channel';
+    }
+    const subGroup = interaction.options.getString("group_name");
+    if (doc.subgroups && !Object.keys(doc.subgroups).includes(subGroup)) {
+        return `🛑 Subscription group **${valueRaw}** does not exists`;
+    }
+
+    let valueRaw = getFirstString(interaction, ["query", "filter", "value", "entity_id"]).toLowerCase();
+
+    if (valueRaw.startsWith(ISK_PREFIX)) {
+        const iskValue = Number(valueRaw.substr(ISK_PREFIX.length));
+        if (Number.isNaN(iskValue)) {
+            return ` ❌ Unable to subscribe... **${valueRaw}** is not a number`;
+        }
+        if (iskValue < 100000000) {
+            return ` ❌ Unable to subscribe... **${valueRaw}** needs to be at least 100 million`;
+        }
+
+        await db.subsCollection.updateOne(
+            { guildId, channelId },
+            { $set: { [`subgroups.${subGroup}.iskValue`]: iskValue } },
+            { upsert: true }
+        );
+
+        return `📡 Subscribed this channel to killmails having iskValue of at least ${iskValue}`;
+    } else if (valueRaw.startsWith(LABEL_PREFIX)) {
+        const label_filter = valueRaw.slice(LABEL_PREFIX.length).trim().toLowerCase();
+        if (LABEL_FILTERS.indexOf(label_filter) < 0) {
+            return ` ❌ Unable to subscribe to label **${label_filter}**, it is not one of the following:\n` + LABEL_FILTERS.join(', ');
+        }
+
+        await db.subsCollection.updateOne(
+            { guildId, channelId },
+            { $addToSet: { [`subgroups.${subGroup}.labels`]: label_filter } },
+            { upsert: true }
+        );
+
+        return `📡 Subscribed the subscription group ${subGroup} to killmails having label **${label_filter}**`;
+    } else {
+        let entityId = Number(valueRaw);
+        if (Number.isNaN(entityId)) {
+            const res = await fetch(`https://zkillboard.com/cache/1hour/autocomplete/?query=${valueRaw}`);
+            let suggestions = (await res.json()).suggestions;
+
+            // we will add groups, but omitting for now
+            suggestions = suggestions.filter(
+                s => !s.value.includes("(Closed)") && s.data.type != "group"
+            );
+
+            if (suggestions.length > 1) {
+                const formatted = suggestions
+                    .map(s => `${s.data.id} — ${s.value} (${s.data.type})`)
+                    .join("\n");
+
+                return ` ❕Too many results for **${valueRaw}**, pick one by ID or use a more specific query:\n${formatted}`;
+            }
+
+            if (suggestions.length == 0) {
+                return ` ❌ Unable to subscribe... **${valueRaw}** did not come up with any search results`;
+            }
+            entityId = suggestions[0].data.id;
+        }
+
+        let names = await getNames(db, [entityId]);
+        if (Object.values(names).length === 0) {
+            return ` ❌ Unable to subscribe... **${valueRaw}** is not a valid entity id`;
+        }
+        const name = names[entityId];
+
+        await db.subsCollection.updateOne(
+            { guildId, channelId },
+            { $addToSet: { [`subgroups.${subGroup}.entityIds`]: entityId } },
+            { upsert: true }
+        );
+
+        await db.entities.updateOne(
+            { entity_id: entityId, name: name },
+            { $setOnInsert: { last_updated: unixtime() } },
+            { upsert: true }
+        );
+
+        return `📡 Subscribed the subscription group ${subGroup} to ${name}`;
+    }
+}

--- a/services/discord-interactions/subgroup/create.js
+++ b/services/discord-interactions/subgroup/create.js
@@ -1,0 +1,17 @@
+import {getFirstString} from "../../../util/helpers.js";
+
+export async function interaction(db, interaction) {
+    const { channelId } = interaction;
+
+    let doc = await db.subsCollection.findOne({ channelId: channelId });
+    if (!doc || doc.checked != true) {
+        return ' 🛑 Before you create a subscription group, please run `/zkillbot check`` to ensure all permissions are set properly for this channel';
+    }
+    // TODO: Potentially cache known names of subgroups for channels
+    let valueRaw = getFirstString(interaction, ["group_name"]);
+    if (doc.subgroups && Object.keys(doc.subgroups).includes(valueRaw)) {
+        return `🛑 Subscription group **${valueRaw}** already exists`;
+    }
+    await db.subsCollection.updateOne({ channelId: channelId }, { $set: { [`subgroups.${valueRaw}`]: {} } });
+    return `✅ Successfully added subscription group **${valueRaw}**`
+}

--- a/services/discord-interactions/subgroup/delete.js
+++ b/services/discord-interactions/subgroup/delete.js
@@ -1,0 +1,17 @@
+import {getFirstString} from "../../../util/helpers.js";
+
+export async function interaction(db, interaction) {
+    const { channelId } = interaction;
+
+    let doc = await db.subsCollection.findOne({ channelId: channelId });
+    if (!doc || doc.checked != true) {
+        return ' 🛑 Before you remove a subscription group, please run `/zkillbot check`` to ensure all permissions are set properly for this channel';
+    }
+    // TODO: Potentially cache known names of subgroups for channels
+    let valueRaw = getFirstString(interaction, ["group_name"]);
+    if (doc.subgroups && !Object.keys(doc.subgroups).includes(valueRaw)) {
+        return `🛑 Subscription group **${valueRaw}** does not exists`;
+    }
+    await db.subsCollection.updateOne({ channelId: channelId }, { $unset: { [`subgroups.${valueRaw}`]: {} } });
+    return `✅ Successfully removed subscription group **${valueRaw}**`
+}

--- a/services/discord-interactions/subgroup/remove.js
+++ b/services/discord-interactions/subgroup/remove.js
@@ -1,0 +1,59 @@
+import { ISK_PREFIX, LABEL_PREFIX, LABEL_FILTERS } from "../../../util/constants.js";
+import { getNames } from "../../information.js";
+import { getFirstString } from "../../../util/helpers.js";
+
+export async function interaction(db, interaction) {
+    const { guildId, channelId } = interaction;
+
+    let doc = await db.subsCollection.findOne({ channelId: channelId });
+
+    const subGroup = interaction.options.getString("group_name");
+    if (doc.subgroups && !Object.keys(doc.subgroups).includes(subGroup)) {
+        return `🛑 Subscription group **${valueRaw}** does not exists`;
+    }
+
+    let valueRaw = getFirstString(interaction, ["query", "filter", "value", "entity_id"]);
+
+    if (valueRaw.startsWith(ISK_PREFIX)) {
+        const res = await db.subsCollection.updateOne(
+            { guildId, channelId },
+            { $unset: { [`subgroups.${subGroup}.iskValue`]: 1 } }
+        );
+
+        if (res.modifiedCount > 0) {
+            return `❌ Unsubscribed the subscription group ${subGroup} from killmails of a minimum isk value`;
+        } else {
+            return `⚠️ No subscription found for killmails of a minimum isk value`;
+        }
+    }
+
+    if (valueRaw.startsWith(LABEL_PREFIX)) {
+        const label_filter = valueRaw.substr(LABEL_PREFIX.length);
+        const res = await db.subsCollection.updateOne(
+            { guildId, channelId },
+            { $pull: { [`subgroups.${subGroup}.labels`]: label_filter } }
+        );
+
+        if (res.modifiedCount > 0) {
+            return `❌ Unsubscribed the subscription group ${subGroup} from label **${label_filter}**`;
+        } else {
+            return `⚠️ No subscription found for label **${label_filter}**`;
+        }
+    }
+
+    const entityId = Number(valueRaw);
+    if (Number.isNaN(entityId)) {
+        return ` ❌ Unable to unsubscribe... **${valueRaw}** is not a number`;
+    }
+
+    const res = await db.subsCollection.updateOne(
+        { guildId, channelId },
+        { $pull: { [`subgroups.${subGroup}.entityIds`]: entityId } }
+    );
+
+    if (res.modifiedCount > 0) {
+        return `❌ Unsubscribed the subscription group ${subGroup} from **${entityId}**`;
+    } else {
+        return `⚠️ No subscription found for **${entityId}**`;
+    }
+}

--- a/services/pollRedisQ.js
+++ b/services/pollRedisQ.js
@@ -89,6 +89,11 @@ export async function pollRedisQ(db, REDISQ_URL) {
 				}
 			}
 
+            // Subgroups
+            {
+                //TODO: Implement
+            }
+
 			app_status.redisq_count++;
 		}
 	} catch (err) {

--- a/util/subgroup.js
+++ b/util/subgroup.js
@@ -1,0 +1,11 @@
+export async function handleGroupName(db, interaction) {
+    const sub = await db.subsCollection.findOne({channelId: interaction.channel.id});
+    const groupName = interaction.options.getString('group_name');
+    if (!sub || !sub.subgroups) interaction.respond([])
+    interaction.respond(Object.keys(sub.subgroups)
+        .filter(g => g.toLowerCase().includes(groupName.toLowerCase()))
+        .map(g => ({name: g, value: g}))
+        .splice(0, 25)
+    );
+
+}


### PR DESCRIPTION
Inital draft for subscription groups, todos:

- maybe cache some of the group names
- cleanup duplicate code between add/remove and subscribe/unsubscribe
- implement redis polling